### PR TITLE
Allow multiple outcomes at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ We appreciate everybody trying to use our software, so we try to come back to yo
 ### Requirements
 MR-link-2 has been tested on MacOS X and Linux combined with Python 3.9, 3.10 and 3.11. 
 Although not tested, every Python version from 3.6 onwards should work.    
-We require some (standard) python packages to be installed, these are: `numpy`, `scipy` and `pandas` and `bitarray`.
+We require some (standard) python packages to be installed, these are: 
+`numpy`, `scipy`, `pandas`, `pyarrow`, `bitarray` and `duckdb`.
 If you want to ensure all the tests run, `pytest` is also necessary.
 If they haven't been installed, please install these using pip.
 In the command line (shell, terminal), type: 
 
 ```{bash}
-pip3 install numpy scipy pandas bitarray pytest
+pip3 install numpy scipy pandas bitarray pytest duckdb pyarrow
 ```
 On top of this, we require plink1.9 to be present in your PATH variable. 
 Check this by typing `which plink` in your  shell. 
@@ -29,9 +30,11 @@ This repository uses pytest to analyze results
 If you want to make sure that everything works as expected, please ensure you have pytest installed and run the 
 following command.
 ```{bash}
-pytest tests/integration_tests_mr_link_2.py
+pytest tests/*
 ```
 For this you need to have everything installed from the requirements, including `pytest`
+If everything passes, you are ready to go! 
+If not all the tests work, please open a github issue, and we'll get back to you ASAP.
 
 ### Example
 If you want to test MR-link-2 we have two examples:
@@ -100,7 +103,7 @@ options:
   --sumstats_exposure SUMSTATS_EXPOSURE
                         The summary statistics file of the exposure file. Please see the README file or the example_files folder for examples on how to make these files.
   
-  --sumstats_outcome SUMSTATS_OUTCOME
+  --sumstats_outcome SUMSTATS_OUTCOME [SUMSTATS_OUTCOME]
                         The summary statistics file of the outcome file. Please see the README file or the example_files folder for examples on how to make these files.
                         We allow multiple outcomes to be analyzed at the same time, include the files separated by spaces
   --out OUT             The path where to output results
@@ -118,6 +121,9 @@ options:
   --var_explained_grid VAR_EXPLAINED_GRID [VAR_EXPLAINED_GRID ...]
                         This field specifies the amount of variance explained of the LD matrix that is used by MR-link-2. You can add onto this field, and all variances explained will be added: --var_explained_grid 0.99 0.999 0.2 0.96 0.1 will perform an MR-link-2 estimate for all these values.
   --continue_analysis   Flag to continue an already started analysis, if specified this will look for a temporary file, and if it present, reuse its results. This can be handy if you have hundreds of associated regions, which can sometimes take a long time to run.
+  --regions_to_read_at_the_same_time NUMBER OF REGIONS
+                        Number of regions to read at the same time from a file. Will reduce I/O times, but can increase memory usage
+                        Only change this when you run into memory errors, or if you want to make a lot of comparisons.
   --prespecified_regions PRESPECIFIED_REGIONS
                         Specify which regions to do. format is the following: 
                         `{chr_1}:{start_1}-{end_1},{chr_2}:{start_2}-{end_2}`. 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ options:
                         The plink bed file prepend of the genotype file that can be used as an LD reference. Usage is the same as in the plink --bed command
   --sumstats_exposure SUMSTATS_EXPOSURE
                         The summary statistics file of the exposure file. Please see the README file or the example_files folder for examples on how to make these files.
+  
   --sumstats_outcome SUMSTATS_OUTCOME
                         The summary statistics file of the outcome file. Please see the README file or the example_files folder for examples on how to make these files.
+                        We allow multiple outcomes to be analyzed at the same time, include the files separated by spaces
   --out OUT             The path where to output results
   --tmp TMP             Not necessary anymore: a prepend on where to save temporary files DEPRECATED
   --p_threshold P_THRESHOLD

--- a/mr_link_2_standalone.py
+++ b/mr_link_2_standalone.py
@@ -14,6 +14,9 @@ from typing import Any, Tuple, Dict
 import tempfile
 import bitarray
 
+import pyarrow.dataset as ds
+import duckdb
+
 from collections import OrderedDict
 
 class PlinkGenoReader:
@@ -1128,7 +1131,7 @@ def read_ld_matrix_local(geno_file_obj: PlinkGenoReader, list_of_snps, maf_thres
                             if not (bool_1 or bool_2)]
     ld_matrix = np.corrcoef(genotypes.T)
 
-    ld_matrix, ordered_snps = remove_highly_correlated(ld_matrix, overlapping_snps, max_correlation)
+    ld_matrix, ordered_snps = remove_highly_correlated(ld_matrix, genotype_matrix_snps, max_correlation)
 
     return ld_matrix, ordered_snps
 
@@ -1204,6 +1207,67 @@ def remove_highly_correlated(ld_matrix, snp_ordering, max_correlation):
     ordered_snps = ordered_snps.loc[~idxs_to_remove, 'snp_names'].tolist()
 
     return ld_matrix, ordered_snps
+
+
+
+def read_multiple_regions_from_parquet_duckdb(filename: str, regions, position_name='base_pair_location'):
+    # Create the dataset object
+    dataset = ds.dataset(filename, format='parquet', partitioning='hive')
+
+    # Connect to DuckDB
+    con = duckdb.connect()
+
+    # Register the dataset in DuckDB
+    con.register('sumstats', dataset)
+
+    # Construct the SQL query to fetch data for all regions
+    query_conditions = []
+    for region in regions:
+        chromosome = region.chromosome
+        start_position = region.start
+        end_position = region.end
+        condition = f"(chromosome = {chromosome} AND {position_name} > {start_position} AND {position_name} <= {end_position})"
+        query_conditions.append(condition)
+
+    query = "SELECT * FROM sumstats WHERE " + " OR ".join(query_conditions) + ";"
+
+    # Execute the query and fetch the result as a DataFrame
+    df = con.execute(query).df()
+    return df
+
+def read_regions_from_file(filename, region_or_regions):
+
+    original_input_to_gwas_catalog_dict = {'pos_name': 'rsid', 'position': 'base_pair_location', 'reference_allele': 'other_allele',
+                                           'se':'standard_error', 'pval': 'p_value', 'n_iids': 'n'}
+
+    if isinstance(region_or_regions, StartEndRegion):
+        regions = [region_or_regions]
+    elif isinstance(region_or_regions, list):
+        regions = region_or_regions
+    else:
+        raise NotImplementedError(f'Only StartEndRegion or list allowed in the constructor found: {region_or_regions.__type__}')
+
+    if filename[-5:] == '.parq':
+        ## parquet file
+
+        try:
+            return_df = read_multiple_regions_from_parquet_duckdb(filename, regions)
+        except:
+             return_df = read_multiple_regions_from_parquet_duckdb(filename, regions, position_name='position')
+
+        return_df = return_df.rename(columns=original_input_to_gwas_catalog_dict)
+        return return_df
+
+    else:
+        regions_in_df = []
+        full_df = pd.read_csv(filename, sep='\t')
+        full_df = full_df.rename(columns=original_input_to_gwas_catalog_dict)
+        for region in regions:
+            regions_in_df.append(full_df[(full_df['chromosome'].astype(str) == region.chromosome) &
+                                         (full_df['base_pair_location'].astype(int) > region.start) &
+                                         (full_df['base_pair_location'].astype(int) <= region.end)
+                                         ])
+        return pd.concat(regions_in_df)
 
 
 if __name__ == '__main__':
@@ -1289,6 +1353,11 @@ Pleiotropy robust cis Mendelian randomization
                         action='store_true',
                         help='flag to _not_ normalize summary statistics')
 
+    parser.add_argument('--regions_to_read_at_the_same_time',
+                        type=int,
+                        default=10,
+                        help='Number of regions to read at the same time from a file. Will reduce I/O times, but can increase memory usage')
+
     parser.add_argument('--no_exclude_hla',
                         action='store_true',
                         help='flag to _not_ exclude the HLA region.')
@@ -1322,6 +1391,8 @@ Pleiotropy robust cis Mendelian randomization
     maf_threshold = float(args.maf_threshold)
     max_correlation = float(args.max_correlation)
 
+    read_chunk = int(args.regions_to_read_at_the_same_time)
+
     max_missingness = float(args.max_missingness)
     if 0.0 > max_missingness > 1.0:
         raise ValueError('Missingness needs to be between 0.0 and 1.0')
@@ -1353,7 +1424,12 @@ Pleiotropy robust cis Mendelian randomization
         tmp_exposure_sumstats_file = f'{tmp_dir}_exposure_sumstats.txt'
         files_to_remove.add(tmp_exposure_sumstats_file)
 
-        exposure_df = pd.read_csv(sumstats_exposure, sep='\t')
+        ## Can also be a parquet file.
+        if sumstats_exposure[-5:] == '.parq':
+            exposure_df = pd.read_parquet(sumstats_exposure)
+        else:
+            exposure_df = pd.read_csv(sumstats_exposure, sep='\t')
+
         exposure_df = exposure_df.rename(columns=original_input_to_gwas_catalog_dict)
         if len(set(exposure_df.columns) & sumstats_necessary_colnames) != len(sumstats_necessary_colnames):
             raise ValueError('Exposure summary statistics do not contain the necessary columns.\n'
@@ -1438,95 +1514,143 @@ Pleiotropy robust cis Mendelian randomization
             combined_df = pd.concat(all_results)
 
         exceptions = []
-        for region in regions_to_do:
-            regional_exposure_df = exposure_df[
-                (exposure_df.chromosome.astype(str) == region.chromosome) &
-                (exposure_df.base_pair_location.astype(int) >= region.start) &
-                (exposure_df.base_pair_location.astype(int) <= region.end)
-                ].copy()
-
+        """
+        HERE, we perform the reading of chunks 
+        """
+        for i in range(0, len(regions_to_do), read_chunk):
+            regions_chunk = regions_to_do[i:i + read_chunk]
+            chunked_regions_per_outcome = {}
+            """
+            This is an optimization and I don't love it. 
+            But can save like 5x of the time, so I'll take the time saving
+            
+            In essence what we do is load in up to <read_chunks> regions of the outcome files.
+            After which we apply MR-link-2 on all the loaded files. 
+            
+            In profiling, I found that this is substantially faster than reading a region one at a time.
+            
+            This is especially valuable when we analyze parquet files. 
+            
+            """
             for outcome_location in sumstats_outcome:
-
-                regional_results = None
-                if (str(region), outcome_location) in outcome_region_combinations_already_done:
-                    print(f'Already done {outcome_location} on {region}, continueing with the next one')
-                    continue
-
                 """
-                Outcome summary statistics loading and parsing
+                It is necessary to also check if the region has been done before.
+                makes it look ugly, but retains robustness and removes double work.
                 """
-                outcome_df = pd.read_csv(outcome_location, sep='\t')
-                outcome_df = outcome_df.rename(columns=original_input_to_gwas_catalog_dict)
+                regions_for_this_outcome = []
+                for region in regions_chunk:
+                    if (str(region), outcome_location) in outcome_region_combinations_already_done:
+                        print(f'Already done {outcome_location} with {region}, continueing with the next one')
+                        continue
+                    regions_for_this_outcome.append(region)
 
-                if len(set(outcome_df.columns) & sumstats_necessary_colnames) != len(sumstats_necessary_colnames):
-                    raise ValueError('Outcome summary statistics do not contain the necessary columns.\n'
-                                     f'The following columns should at least be present:\n{sumstats_necessary_colnames}\n'
-                                     f'The following columns are present: {outcome_df.columns}')
-                if verbosity:
-                    print(f'before missingness filter: {outcome_df.shape=}')
-                outcome_df = outcome_df[outcome_df.n >= (max_missingness * outcome_df.n.max())]
+                if len(regions_for_this_outcome):
+                    start = time.time()
+                    chunked_regions_per_outcome[outcome_location] = read_regions_from_file(
+                        outcome_location, regions_chunk)
+                    end = time.time()
 
-                if not args.no_normalize_sumstats:
-                    outcome_df['z'] = outcome_df['beta'] / outcome_df['standard_error']
-                    outcome_df['beta'] = outcome_df.z / np.sqrt(outcome_df.n + outcome_df.z ** 2)
-                    outcome_df['standard_error'] = 1 / np.sqrt(outcome_df.n + outcome_df.z ** 2)
+                    if True or verbosity:
+                        print(f'Read {outcome_location} {len(regions_chunk)} in {end - start:.2f}s')
 
-                if verbosity:
-                    print(f'after missingness filter: {outcome_df.shape=}')
+            """
+            And now to continue with the MR-link-2
+            """
+            for region in regions_chunk:
+                regional_exposure_df = exposure_df[
+                    (exposure_df.chromosome.astype(str) == region.chromosome) &
+                    (exposure_df.base_pair_location.astype(int) >= region.start) &
+                    (exposure_df.base_pair_location.astype(int) <= region.end)
+                    ].copy()
+
+                for outcome_location in sumstats_outcome:
+
+                    regional_results = None
+                    if (str(region), outcome_location) in outcome_region_combinations_already_done:
+                        print(f'Already done {outcome_location} on {region}, continueing with the next one')
+                        continue
+
+                    """
+                    Outcome summary statistics loading and parsing
+                    """
+                    outcome_df = chunked_regions_per_outcome[outcome_location]
+                    regional_outcome_df = outcome_df[
+                        (outcome_df.chromosome.astype(str) == region.chromosome) &
+                        (outcome_df.base_pair_location.astype(int) >= region.start) &
+                        (outcome_df.base_pair_location.astype(int) <= region.end)
+                        ].copy()
+
+                    regional_outcome_df = regional_outcome_df.rename(columns=original_input_to_gwas_catalog_dict)
+
+                    if len(set(outcome_df.columns) & sumstats_necessary_colnames) != len(sumstats_necessary_colnames):
+                        raise ValueError('Outcome summary statistics do not contain the necessary columns.\n'
+                                         f'The following columns should at least be present:\n{sumstats_necessary_colnames}\n'
+                                         f'The following columns are present: {outcome_df.columns}')
+                    if verbosity:
+                        print(f'before missingness filter: {regional_outcome_df.shape=}')
+                    regional_outcome_df = regional_outcome_df[regional_outcome_df.n >= (max_missingness * regional_outcome_df.n.max())]
+
+                    if not args.no_normalize_sumstats:
+                        regional_outcome_df['z'] = regional_outcome_df['beta'] / regional_outcome_df['standard_error']
+                        regional_outcome_df['beta'] = regional_outcome_df.z / np.sqrt(regional_outcome_df.n + regional_outcome_df.z ** 2)
+                        regional_outcome_df['standard_error'] = 1 / np.sqrt(regional_outcome_df.n + regional_outcome_df.z ** 2)
+
+                    if verbosity:
+                        print(f'after missingness filter: {regional_outcome_df.shape=}')
 
 
 
 
-                regional_ld_matrix, snps_in_ld_matrix = read_ld_matrix_local(plink_geno_obj,
-                                                                             regional_exposure_df.rsid,
-                                                                             maf_threshold=maf_threshold,
-                                                                             max_correlation=max_correlation,
-                                                                             )
-                snps_and_alleles_in_ld_matrix = [(x, plink_geno_obj.bim_data[x][2], plink_geno_obj.bim_data[x][3]) for x in
-                                                 snps_in_ld_matrix]
+                    regional_ld_matrix, snps_in_ld_matrix = read_ld_matrix_local(plink_geno_obj,
+                                                                                 regional_exposure_df.rsid,
+                                                                                 maf_threshold=maf_threshold,
+                                                                                 max_correlation=max_correlation,
+                                                                                 )
+                    snps_and_alleles_in_ld_matrix = [(x, plink_geno_obj.bim_data[x][2], plink_geno_obj.bim_data[x][3]) for x in
+                                                     snps_in_ld_matrix]
 
-                try:
-                    regional_results = mr_link2_on_region(region,
-                                                          regional_exposure_df,
-                                                          outcome_df,
-                                                          reference_bed,
-                                                          maf_threshold,
-                                                          max_correlation,
-                                                          regional_ld_matrix,
-                                                          snps_alleles_in_ld_matrix=snps_and_alleles_in_ld_matrix,
-                                                          tmp_prepend=tmp_dir,
-                                                          verbosity=verbosity,
-                                                          var_explained_grid=var_explained_grid)
-                except Exception as x:
-                    exceptions.append((region, x))
-                    print(f'Unable to make an MR-link2 estimate in {region} due to {x}')
-                    continue
+                    try:
+                        regional_results = mr_link2_on_region(region,
+                                                              regional_exposure_df,
+                                                              regional_outcome_df,
+                                                              reference_bed,
+                                                              maf_threshold,
+                                                              max_correlation,
+                                                              regional_ld_matrix,
+                                                              snps_alleles_in_ld_matrix=snps_and_alleles_in_ld_matrix,
+                                                              tmp_prepend=tmp_dir,
+                                                              verbosity=verbosity,
+                                                              var_explained_grid=var_explained_grid)
+                    except Exception as x:
+                        exceptions.append((region, x))
+                        print(f'Unable to make an MR-link2 estimate in {region} due to {x}')
+                        continue
 
-                if regional_results is None:
-                    exceptions.append((region, 'NONE_RESULT'))
-                    print('Unable to identify mr-link2 results in {region} region')
-                    continue
+                    if regional_results is None:
+                        exceptions.append((region, 'NONE_RESULT'))
+                        print(f'Unable to identify mr-link2 results in {region} region')
+                        continue
 
-                regional_results['exposure_file'] = sumstats_exposure
-                regional_results['outcome_file'] = outcome_location
+                    regional_results['exposure_file'] = sumstats_exposure
+                    regional_results['outcome_file'] = outcome_location
 
-                all_results.append(regional_results)
-                combined_df = pd.concat(all_results)
-                combined_df.to_csv(args.out + '_tmp', sep='\t', index=False)
+                    all_results.append(regional_results)
+                    combined_df = pd.concat(all_results)
+                    combined_df.to_csv(args.out + '_tmp', sep='\t', index=False)
 
-        # write results
-        if len(all_results) != 0 and combined_df is not None:
-            combined_df.to_csv(args.out, sep='\t', index=False)
-            if os.path.exists(args.out + '_tmp'):
-                os.remove(args.out + '_tmp')
+            # write results
+            if len(all_results) != 0 and combined_df is not None:
+                combined_df.to_csv(args.out, sep='\t', index=False)
+                if os.path.exists(args.out + '_tmp'):
+                    os.remove(args.out + '_tmp')
 
-        # write exceptions to a file
-        if len(exceptions) != 0:
-            with open(args.out + '_no_estimate', 'a') as f:
-                for region, exception in exceptions:
-                    f.write(f'{region}\t{exception}\n')
+            # write exceptions to a file
+            if len(exceptions) != 0:
+                with open(args.out + '_no_estimate', 'a') as f:
+                    for region, exception in exceptions:
+                        f.write(f'{region}\t{exception}\n')
 
-        # finally, clean up
-        for filename in files_to_remove:
-            if os.path.exists(filename):
-                os.remove(filename)
+            # finally, clean up
+            for filename in files_to_remove:
+                if os.path.exists(filename):
+                    os.remove(filename)

--- a/tests/integration_tests_mr_link_2.py
+++ b/tests/integration_tests_mr_link_2.py
@@ -219,3 +219,45 @@ def test_mr_link_2_integration_non_causal_gwas_catalog_format():
         assert np.isclose(data_frame['se(sigma_y)'], 0.0066189399600698)
         assert np.isclose(data_frame['p(sigma_y)'], 7.011323342257353e-136)
 
+
+
+
+def test_mr_link_2_integration_on_multiple_outcomes():
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_loc = f'{tmpdir}/tmp_integration_testing_'
+
+        command = [
+            sys.executable, f"{current_dir}/../mr_link_2_standalone.py",
+            "--reference_bed", f"{current_dir}/../example_files/reference_cohort",
+            "--sumstats_exposure", f"{current_dir}/../example_files/non_causal_exposure.txt",
+            "--sumstats_outcome",
+                f"{current_dir}/../example_files/gwas_catalog_format.txt",
+                f'{current_dir}/../example_files/yes_causal_outcome.txt',
+            "--out", f'{tmp_loc}_gwas_catalog_format_and_other.txt'
+        ]
+
+        result = subprocess.run(command, capture_output=True, text=True)
+        assert result.returncode == 0, f"Command failed with return code {result.returncode}. Output: {result.stdout} Error: {result.stderr}"
+
+        data_frame = pd.read_csv(f'{tmp_loc}_gwas_catalog_format_and_other.txt', sep='\t')
+
+        assert np.isclose(data_frame.alpha[0], -0.0330966574547156)
+        assert np.isclose(data_frame['se(alpha)'][0], 0.0529061811094349)
+        assert np.isclose(data_frame['p(alpha)'][0], 0.5315953131580522)
+
+        assert np.isclose(data_frame.sigma_x[0],0.5641943699065054)
+        assert np.isclose(data_frame.sigma_y[0], 0.1642151919013568)
+        assert np.isclose(data_frame['se(sigma_y)'][0], 0.0066189399600698)
+        assert np.isclose(data_frame['p(sigma_y)'][0], 7.011323342257353e-136)
+
+        ## Second outcome
+        assert np.isclose(data_frame.alpha[1], -0.1042118931465468)
+        assert np.isclose(data_frame['se(alpha)'][1], 0.0586538510326496)
+        assert np.isclose(data_frame['p(alpha)'][1], 0.0756131330132535)
+
+        assert np.isclose(data_frame.sigma_x[1],0.5655293785994038)
+        assert np.isclose(data_frame.sigma_y[1], 0.2337825514636705)
+        assert np.isclose(data_frame['se(sigma_y)'][1], 0.0053092285613672)
+        assert np.isclose(data_frame['p(sigma_y)'][1], 0.0)

--- a/tests/integration_tests_mr_link_2.py
+++ b/tests/integration_tests_mr_link_2.py
@@ -261,3 +261,46 @@ def test_mr_link_2_integration_on_multiple_outcomes():
         assert np.isclose(data_frame.sigma_y[1], 0.2337825514636705)
         assert np.isclose(data_frame['se(sigma_y)'][1], 0.0053092285613672)
         assert np.isclose(data_frame['p(sigma_y)'][1], 0.0)
+
+
+
+
+def test_mr_link_2_integration_on_multiple_outcomes_parquet_format():
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_loc = f'{tmpdir}/tmp_integration_testing_'
+
+        command = [
+            sys.executable, f"{current_dir}/../mr_link_2_standalone.py",
+            "--reference_bed", f"{current_dir}/../example_files/reference_cohort",
+            "--sumstats_exposure", f"{current_dir}/../example_files/non_causal_exposure.parq",
+            "--sumstats_outcome",
+                f"{current_dir}/../example_files/gwas_catalog_format.parq",
+                f"{current_dir}/../example_files/yes_causal_outcome.parq",
+            "--out", f'{tmp_loc}_gwas_catalog_format_and_other.txt'
+        ]
+
+        result = subprocess.run(command, capture_output=True, text=True)
+        assert result.returncode == 0, f"Command failed with return code {result.returncode}. Output: {result.stdout} Error: {result.stderr}"
+
+        data_frame = pd.read_csv(f'{tmp_loc}_gwas_catalog_format_and_other.txt', sep='\t')
+
+        assert np.isclose(data_frame.alpha[0], -0.0330966574547156)
+        assert np.isclose(data_frame['se(alpha)'][0], 0.0529061811094349)
+        assert np.isclose(data_frame['p(alpha)'][0], 0.5315953131580522)
+
+        assert np.isclose(data_frame.sigma_x[0],0.5641943699065054)
+        assert np.isclose(data_frame.sigma_y[0], 0.1642151919013568)
+        assert np.isclose(data_frame['se(sigma_y)'][0], 0.0066189399600698)
+        assert np.isclose(data_frame['p(sigma_y)'][0], 7.011323342257353e-136)
+
+        ## Second outcome
+        assert np.isclose(data_frame.alpha[1], -0.1042118931465468)
+        assert np.isclose(data_frame['se(alpha)'][1], 0.0586538510326496)
+        assert np.isclose(data_frame['p(alpha)'][1], 0.0756131330132535)
+
+        assert np.isclose(data_frame.sigma_x[1],0.5655293785994038)
+        assert np.isclose(data_frame.sigma_y[1], 0.2337825514636705)
+        assert np.isclose(data_frame['se(sigma_y)'][1], 0.0053092285613672)
+        assert np.isclose(data_frame['p(sigma_y)'][1], 0.0)


### PR DESCRIPTION
Large refactor.
This allows us to read multiple outcomes at the same time, which reduces the need to read in an LD matrix too often.

Furthermore, some other changes in the interest of processing speed.

First: added a feature to read in parquet files. Parquet files are easier to read, but this comes at the added cost of requiring the pyarrow and duckdb libraries.

Secondly: Included some optimizations to read in multiple regions at a time, this will reduce the io load when there are many regions to read at the same time. This is the bottleneck when you want to make a lot of comparisons.

Thirdly: fixed a bug where missing genotypes are not correctly taken into account when reading an LD matrix.