### PR TITLE
R functions of mr link 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run integration tests
         run: pytest tests/integration_tests_mr_link_2.py
+
+      - name: Run comparison_tests_with_r_imlementation
+        run: pytest tests/test_for_r_and_python_concordance.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,34 @@
 name: Test
 on: [push, pull_request]
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - name: Install dependencies
+
+      - name: Install R
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y r-base r-base-dev
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install numpy scipy pandas pytest bitarray duckdb pyarrow
+          pip install numpy scipy pandas pytest bitarray duckdb pyarrow rpy2
 
       - name: Download and install plink
         run: |

--- a/R/mr_link_2_functions.R
+++ b/R/mr_link_2_functions.R
@@ -70,3 +70,141 @@ mr_link2_loglik_sigma_y_h0 <- function(th, lam, c_x, c_y, n_x, n_y) {
 
   return(-loglik)
 }
+
+
+
+mr_link2 <- function(selected_eigenvalues, selected_eigenvectors,
+                     exposure_betas, outcome_betas,
+                     n_exp, n_out, sigma_exp_guess, sigma_out_guess) {
+
+  start_time <- Sys.time()
+
+  # Define optimization options
+  method <- "Nelder-Mead"
+  control <- list(maxit = 100000)
+
+  # Calculate c_x and c_y
+  c_x <- t(selected_eigenvectors) %*% exposure_betas
+  c_y <- t(selected_eigenvectors) %*% outcome_betas
+
+  max_sigma <- sqrt(.Machine$double.xmax)
+
+  # Alpha h0 estimation
+  alpha_h0_guesses <- list(c(sigma_exp_guess, sigma_out_guess),
+                           c(max_sigma, max_sigma),
+                           c(1, max_sigma),
+                           c(1e3, 1e3))
+
+  alpha_h0_results <- optim(par = alpha_h0_guesses[[1]],
+                            fn = mr_link2_loglik_alpha_h0,
+                            gr = NULL,
+                            selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                            method = method, control = control)
+
+  # Loop over other guesses
+  for (alpha_h0_guess in alpha_h0_guesses[-1]) {
+    if (alpha_h0_results$convergence == 0) break
+
+    new_alpha_h0_results <- optim(par = alpha_h0_guess,
+                                  fn = mr_link2_loglik_alpha_h0,
+                                  gr = NULL,
+                                  selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                                  method = method, control = control)
+
+    if (alpha_h0_results$value >= new_alpha_h0_results$value) {
+      alpha_h0_results <- new_alpha_h0_results
+    }
+  }
+
+  # Sigma_y estimation
+  sigma_y_guesses <- list(c(0.0, sigma_exp_guess),
+                          c(1.0, sigma_exp_guess),
+                          c(0.0, alpha_h0_results$par[1]),
+                          c(1.0, alpha_h0_results$par[1]),
+                          c(0.0, max_sigma),
+                          c(1e-10, max_sigma))
+
+  sigma_y_h0_results <- optim(par = sigma_y_guesses[[1]],
+                              fn = mr_link2_loglik_sigma_y_h0,
+                              gr = NULL,
+                              selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                              method = method, control = control)
+
+  for (sigma_y_guess in sigma_y_guesses[-1]) {
+    if (sigma_y_h0_results$convergence == 0) break
+
+    new_sigma_y_h0_results <- optim(par = sigma_y_guess,
+                                    fn = mr_link2_loglik_sigma_y_h0,
+                                    gr = NULL,
+                                    selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                                    method = method, control = control)
+
+    if (new_sigma_y_h0_results$value < sigma_y_h0_results$value) {
+      sigma_y_h0_results <- new_sigma_y_h0_results
+    }
+  }
+
+  # Ha estimation
+  ha_guesses <- list(c(0.0, alpha_h0_results$par[1], alpha_h0_results$par[2]),
+                     c(sigma_y_h0_results$par[1], sigma_y_h0_results$par[2], sqrt(.Machine$double.xmax)),
+                     c(1.0, alpha_h0_results$par[1], alpha_h0_results$par[2]),
+                     c(1e-10, max_sigma, max_sigma))
+
+  ha_results <- optim(par = ha_guesses[[1]],
+                      fn = mr_link2_loglik_reference_v2,
+                      gr = NULL,
+                      selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                      method = method, control = control)
+
+  for (ha_guess in ha_guesses[-1]) {
+    if (ha_results$convergence == 0) break
+
+    new_ha_result <- optim(par = ha_guess,
+                           fn = mr_link2_loglik_reference_v2,
+                           gr = NULL,
+                           selected_eigenvalues, c_x, c_y, n_exp, n_out,
+                           method = method, control = control)
+
+    if (new_ha_result$value < ha_results$value) {
+      ha_results <- new_ha_result
+    }
+  }
+
+  # Likelihood Ratio Test and Estimation
+  alpha <- ha_results$par[1]
+  alpha_chi_sq <- 2 * (alpha_h0_results$value - ha_results$value)
+  alpha_p_val <- pchisq(alpha_chi_sq, df = 1, lower.tail = FALSE)
+  z_alpha <- ifelse(alpha_chi_sq <= 0, 0.0, sign(alpha) * sqrt(alpha_chi_sq))
+  se_alpha <- ifelse(z_alpha != 0, alpha / z_alpha, NA)
+
+  sigma_y <- 1 / abs(ha_results$par[3])
+  sigma_y_chi_sq <- 2 * (sigma_y_h0_results$value - ha_results$value)
+  sigma_y_p_val <- pchisq(sigma_y_chi_sq, df = 1, lower.tail = FALSE)
+  z_sigma_y <- ifelse(sigma_y_chi_sq <= 0, 0.0, sqrt(sigma_y_chi_sq))
+  se_sigma_y <- ifelse(z_sigma_y != 0, sigma_y / z_sigma_y, NA)
+
+  # Return results as a list (equivalent to Python's dictionary)
+  list(
+    alpha = alpha,
+    `se(alpha)` = se_alpha,
+    `p(alpha)` = alpha_p_val,
+    sigma_y = sigma_y,
+    `se(sigma_y)` = se_sigma_y,
+    `p(sigma_y)` = sigma_y_p_val,
+    sigma_x = 1 / abs(ha_results$par[2]),
+    alpha_h0_sigma_x = 1 / abs(alpha_h0_results$par[1]),
+    alpha_h0_sigma_y = 1 / abs(alpha_h0_results$par[2]),
+    alpha_h0_loglik = alpha_h0_results$value,
+    sigma_y_h0_alpha = sigma_y_h0_results$par[1],
+    sigma_y_h0_sigma_x = 1 / abs(sigma_y_h0_results$par[2]),
+    sigma_y_h0_loglik = sigma_y_h0_results$value,
+    ha_loglik = ha_results$value,
+    optim_alpha_h0_success = alpha_h0_results$convergence == 0,
+    optim_alpha_h0_nit = alpha_h0_results$counts,
+    optim_sigma_y_h0_success = sigma_y_h0_results$convergence == 0,
+    optim_sigma_y_h0_nit = sigma_y_h0_results$counts,
+    optim_ha_success = ha_results$convergence == 0,
+    optim_ha_nit = ha_results$counts,
+    function_time = as.numeric(difftime(Sys.time(), start_time, units = "secs"))
+  )
+}

--- a/R/mr_link_2_functions.R
+++ b/R/mr_link_2_functions.R
@@ -1,0 +1,72 @@
+mr_link2_loglik_reference_v2 <- function(th, lam, c_x, c_y, n_x, n_y) {
+  # Convert n_x and n_y to float
+  n_x <- as.numeric(n_x)
+  n_y <- as.numeric(n_y)
+  a <- th[1]
+  tX <- abs(th[2])
+  tY <- abs(th[3])
+
+  Dyy <- 1 / (n_y * lam + tY)
+
+  if (a != 0) {
+    Dxx <- 1 / (exp(log(a^2 * n_y + n_x) + log(lam)) + tX -
+                exp(log(a^2 * n_y^2 * lam^2) - log(n_y * lam + tY)))
+    Dxy <- -Dxx * a * exp(log(n_y * lam) - log(n_y * lam + tY))
+    Dyy <- Dyy + exp(log(Dxx * (a^2 * n_y^2 * lam^2)) - (2 * log(n_y * lam + tY)))
+    asq_ny_sq_lam_sq_div_ny_lam_ty <- exp(log(a^2 * n_y^2 * lam^2) - log(n_y * lam + tY))
+  } else {
+    Dxx <- 1 / (exp(log(n_x) + log(lam)) + tX)
+    Dxy <- -Dxx * a * exp(log(n_y * lam) - log(n_y * lam + tY))
+    asq_ny_sq_lam_sq_div_ny_lam_ty <- 0 * lam
+  }
+
+  dX <- n_x * c_x + a * n_y * c_y
+  dY <- n_y * c_y
+  m <- length(c_x)
+
+  loglik <- -m * log(2 * pi) -
+            (1 / 2) * sum(log((a^2 * n_y + n_x) * lam + tX - asq_ny_sq_lam_sq_div_ny_lam_ty)) -
+            (1 / 2) * sum(log(n_y * lam + tY)) +
+            (1 / 2) * (sum(dX^2 * Dxx) + 2 * sum(dX * dY * Dxy) + sum(dY^2 * Dyy)) -
+            (n_x / 2) * sum((c_x^2) / lam) -
+            (n_y / 2) * sum((c_y^2) / lam) +
+            (m / 2) * (log(n_x) + log(n_y)) - sum(log(lam)) + (m / 2) * (log(tX) + log(tY))
+
+  return(-loglik)
+}
+
+mr_link2_loglik_alpha_h0 <- function(th, lam, cX, cY, nX, nY) {
+  return(mr_link2_loglik_reference_v2(c(0, th[1], th[2]), lam, cX, cY, nX, nY))
+}
+
+mr_link2_loglik_sigma_y_h0 <- function(th, lam, c_x, c_y, n_x, n_y) {
+  n_x <- as.numeric(n_x)
+  n_y <- as.numeric(n_y)
+  a <- th[1]
+  tX <- abs(th[2])
+
+  Dyy <- rep(0, length(lam))
+
+  if (a != 0) {
+    Dxx <- 1 / (exp(log(a^2 * n_y + n_x) + log(lam)) + tX)
+    Dxy <- rep(0, length(lam))
+    asq_ny_sq_lam_sq_div_ny_lam_ty <- rep(0, length(lam))
+  } else {
+    Dxx <- 1 / (exp(log(n_x) + log(lam)) + tX)
+    Dxy <- rep(0, length(lam))
+    asq_ny_sq_lam_sq_div_ny_lam_ty <- rep(0, length(lam))
+  }
+
+  dX <- n_x * c_x + a * n_y * c_y
+  dY <- n_y * c_y
+  m <- length(c_x)
+
+  loglik <- -m * log(2 * pi) -
+            (1 / 2) * sum(log((a^2 * n_y + n_x) * lam + tX - asq_ny_sq_lam_sq_div_ny_lam_ty)) +
+            (1 / 2) * (sum(dX^2 * Dxx) + 2 * sum(dX * dY * Dxy) + sum(dY^2 * Dyy)) -
+            (n_x / 2) * sum((c_x^2) / lam) -
+            (n_y / 2) * sum((c_y^2) / lam) +
+            (m / 2) * (log(n_x) + log(n_y)) - sum(log(lam)) + (m / 2) * log(tX)
+
+  return(-loglik)
+}

--- a/mr_link_2_standalone.py
+++ b/mr_link_2_standalone.py
@@ -98,7 +98,7 @@ class PlinkGenoReader:
         for i in range(n_variants):
             bits = bitarray.bitarray(endian="little")
             bits.frombytes(byte_array[offset:(offset+bytes_per_variant)])
-            array = bits.decode(self._decoder)[:self.n_individuals]
+            array = list(bits.decode(self._decoder))[:self.n_individuals]
             genotypes[:,i] = array
             offset+=bytes_per_variant
 

--- a/tests/integration_tests_mr_link_2.py
+++ b/tests/integration_tests_mr_link_2.py
@@ -13,11 +13,6 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from mr_link_2_standalone import *
 
 
-""""
-NB. These tests require us to have plink in your path. 
-So unfortunately I will not test them in the github workflow.
-"""
-
 def test_plink_version():
     result = subprocess.run(['plink', '--version'], capture_output=True, text=True)
     assert result.returncode == 0, "PLINK is not installed or not in the PATH"

--- a/tests/test_for_r_and_python_concordance.py
+++ b/tests/test_for_r_and_python_concordance.py
@@ -1,0 +1,314 @@
+import pytest
+import sys
+import os
+
+## For the python part
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from mr_link_2_standalone import *
+
+
+## for the R part
+
+from rpy2.robjects import r, numpy2ri
+from rpy2.robjects.packages import importr
+
+# Activate automatic conversion between numpy and R objects
+numpy2ri.activate()
+
+# Load the base R package
+base = importr('base')
+# Source the R file with the functions
+r['source']('../R/mr_link_2_functions.R')
+
+"""
+Now, we perform unit tests on the MR-link-2 functions. to ensure that there is no creep of the 
+First function v0
+"""
+def test_mr_link2_loglik_reference_v0_basic_r_concordance():
+    th = np.array([0.1, 0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    expected_result = 22.944216071347796
+    python_result = mr_link2_loglik_reference_v0(th, lam, c_x, c_y, n_x, n_y)
+
+    assert np.isclose(python_result, expected_result)
+    assert np.isclose(python_result, mr_link2_loglik_reference_v2(th, lam, c_x, c_y, n_x, n_y))
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+
+def test_mr_link2_loglik_reference_v0_zero_lam_r_concordance():
+    th = np.array([0.1, 0.01, 0.01])
+    lam = np.array([0, 0, 0])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    python_result = mr_link2_loglik_reference_v0(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isnan(python_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isnan(r_result[0])
+
+def test_mr_link2_loglik_reference_v0_large_values_r_concordance():
+    th = np.array([0.5, 1e10, 1e10])
+    lam = np.array([1e5, 1e5, 1e5])
+    c_x = np.array([1e2, 1e2, 1e2])
+    c_y = np.array([1e2, 1e2, 1e2])
+    n_x = 1e6
+    n_y = 1e6
+
+    expected_result = 17617.166270043643
+    python_result = mr_link2_loglik_reference_v0(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(python_result, expected_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+def test_mr_link2_loglik_reference_v0_negative_values_r_concordance():
+    th = np.array([0.1, -0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    expected_result = 22.944216071347796
+    python_result = mr_link2_loglik_reference_v0(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(python_result, expected_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+
+def test_mr_link2_loglik_reference_v2_basic_r_concordance():
+    th = np.array([0.1, 0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    expected_result = 22.944216071347796
+    python_result = mr_link2_loglik_reference_v2(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(python_result, expected_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+
+
+def test_mr_link2_loglik_reference_v2_zero_lam_r_concordance():
+    th = np.array([0.1, 0.01, 0.01])
+    lam = np.array([0, 0, 0])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    python_result = mr_link2_loglik_reference_v2(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isnan(python_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isnan(r_result[0])
+
+
+def test_mr_link2_loglik_reference_v2_large_values_r_concordance():
+    th = np.array([0.5, 1e10, 1e10])
+    lam = np.array([1e5, 1e5, 1e5])
+    c_x = np.array([1e2, 1e2, 1e2])
+    c_y = np.array([1e2, 1e2, 1e2])
+    n_x = 1e6
+    n_y = 1e6
+
+    expected_result = 17617.166270043643
+    python_result = mr_link2_loglik_reference_v2(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(python_result, expected_result)
+
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+
+def test_mr_link2_loglik_reference_v2_negative_values_r_concordance():
+    th = np.array([0.1, -0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    c_x = np.array([1, 1, 1])
+    c_y = np.array([2, 2, 2])
+    n_x = 100
+    n_y = 100
+
+    expected_result = 22.944216071347796
+    python_result = mr_link2_loglik_reference_v2(th, lam, c_x, c_y, n_x, n_y)
+
+    # Check the Python result against the expected value
+    assert np.isclose(python_result, expected_result)
+
+    # Call the R function and check if it matches the expected value
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(r_result[0], expected_result)
+
+    # Also check against the mr_link2_loglik_reference_v0 function
+    reference_result_v0 = mr_link2_loglik_reference_v0(th, lam, c_x, c_y, n_x, n_y)
+    assert np.isclose(python_result, reference_result_v0)
+
+
+"""
+As we do use them as functions, we want to make sure that the h0 functions also work correctly.
+"""
+def test_mr_link2_loglik_alpha_h0_basic_r_concordance():
+    th = np.array([0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    cX = np.array([1, 1, 1])
+    cY = np.array([2, 2, 2])
+    nX = 100
+    nY = 100
+
+    python_result = mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY)
+    reference_result = mr_link2_loglik_reference_v2([0.0] + list(th), lam, cX, cY, nX, nY)
+
+    assert np.isclose(python_result, reference_result)
+
+    r_result = r['mr_link2_loglik_alpha_h0'](th, lam, cX, cY, nX, nY)
+    assert np.isclose(r_result[0], reference_result)
+
+
+def test_mr_link2_loglik_alpha_h0_zero_lam_r_concordance():
+    th = np.array([0.01, 0.01])
+    lam = np.array([0, 0, 0])
+    cX = np.array([1, 1, 1])
+    cY = np.array([2, 2, 2])
+    nX = 100
+    nY = 100
+    result = mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY)
+    assert np.isnan(result)
+    assert np.isnan(mr_link2_loglik_reference_v2([0.0] + list(th), lam, cX, cY, nX, nY))
+def test_mr_link2_loglik_alpha_h0_large_value_r_concordances():
+    th = np.array([1e10, 1e10])
+    lam = np.array([1e5, 1e5, 1e5])
+    cX = np.array([1e2, 1e2, 1e2])
+    cY = np.array([1e2, 1e2, 1e2])
+    nX = 1e6
+    nY = 1e6
+
+    # Call the Python function for alpha_h0
+    python_result = mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY)
+
+    # Call the Python reference function for comparison
+    reference_result = mr_link2_loglik_reference_v2([0.0] + list(th), lam, cX, cY, nX, nY)
+
+    # Validate Python result
+    assert isinstance(python_result, float)
+    assert np.isclose(python_result, reference_result)
+
+    # Call the R function for alpha_h0 and compare with the Python result
+    r_result = r['mr_link2_loglik_alpha_h0'](th, lam, cX, cY, nX, nY)
+    assert np.isclose(r_result[0], reference_result)
+
+
+def test_mr_link2_loglik_alpha_h0_negative_values_r_concordance():
+    th = np.array([0.01, -0.01])
+    lam = np.array([1, 2, 3])
+    cX = np.array([1, 1, 1])
+    cY = np.array([2, 2, 2])
+    nX = 100
+    nY = 100
+
+    # Call the Python function for alpha_h0
+    python_result = mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY)
+
+    # Call the Python reference function for comparison
+    reference_result = mr_link2_loglik_reference_v2([0.0] + list(th), lam, cX, cY, nX, nY)
+
+    # Validate Python result
+    assert isinstance(python_result, float)
+    assert np.isclose(python_result, reference_result)
+
+    # Call the R function for alpha_h0 and compare with the Python result
+    r_result = r['mr_link2_loglik_alpha_h0'](th, lam, cX, cY, nX, nY)
+    assert np.isclose(r_result[0], reference_result)
+
+
+def test_mr_link2_loglik_alpha_h0_large_population_r_concordance():
+    th = np.array([0.01, 0.01])
+    lam = np.array([1, 2, 3])
+    cX = np.array([1, 1, 1])
+    cY = np.array([2, 2, 2])
+    nX = 1e12
+    nY = 1e12
+
+    # Call the Python function for alpha_h0
+    python_result = mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY)
+
+    # Call the Python reference function for comparison
+    reference_result = mr_link2_loglik_reference_v2([0.0] + list(th), lam, cX, cY, nX, nY)
+
+    # Validate Python result
+    assert isinstance(python_result, float)
+    assert np.isclose(python_result, reference_result)
+
+    # Call the R function for alpha_h0 and compare with the Python result
+    r_result = r['mr_link2_loglik_alpha_h0'](th, lam, cX, cY, nX, nY)
+    assert np.isclose(r_result[0], reference_result)
+
+
+"""
+FUZZ TESTING many many many times.
+"""
+FUZZ_ITERATIONS = 10000
+
+
+def random_input_generator():
+    """Generate random inputs for the test functions."""
+    for _ in range(FUZZ_ITERATIONS):
+        th = np.random.uniform(-1e3, 1e3, size=3)
+        lam = np.random.uniform(1e-5, 1e3, size=500)
+        cX = np.random.uniform(-1e3, 1e3, size=500)
+        cY = np.random.uniform(-1e3, 1e3, size=500)
+        nX = np.random.uniform(50, 1e7)
+        nY = np.random.uniform(50, 1e7)
+
+        yield th, lam, cX, cY, nX, nY
+
+
+@pytest.mark.parametrize("th, lam, cX, cY, nX, nY", random_input_generator())
+def test_fuzz_mr_link2_loglik_reference_v2(th, lam, cX, cY, nX, nY):
+    """Fuzz testing for mr_link2_loglik_reference_v2 between Python and R implementations."""
+    # Python function result
+    python_result = mr_link2_loglik_reference_v2(th, lam, cX, cY, nX, nY)
+
+    # Call R function
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, cX, cY, nX, nY)
+
+    # Convert R result to Python float for comparison
+    r_result_py = float(r_result[0])
+
+    # Compare both results using np.isclose()
+    assert np.isclose(python_result, r_result_py, rtol=1e-5,
+                      atol=1e-8), f"Mismatch for th={th}, lam={lam}, cX={cX}, cY={cY}, nX={nX}, nY={nY}"
+
+
+@pytest.mark.parametrize("th, lam, cX, cY, nX, nY", random_input_generator())
+def test_fuzz_mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY):
+    """Fuzz testing for mr_link2_loglik_alpha_h0 between Python and R implementations."""
+    # Use only the first two elements of 'th' for alpha_h0
+    th_h0 = th[:2]
+
+    # Python function result
+    python_result = mr_link2_loglik_alpha_h0(th_h0, lam, cX, cY, nX, nY)
+
+    # Call R function
+    r_result = r['mr_link2_loglik_alpha_h0'](th_h0, lam, cX, cY, nX, nY)
+
+    # Convert R result to Python float for comparison
+    r_result_py = float(r_result[0])
+
+    # Compare both results using np.isclose()
+    assert np.isclose(python_result, r_result_py, rtol=1e-5,
+                      atol=1e-8), f"Mismatch for th={th}, lam={lam}, cX={cX}, cY={cY}, nX={nX}, nY={nY}"

--- a/tests/test_for_r_and_python_concordance.py
+++ b/tests/test_for_r_and_python_concordance.py
@@ -312,3 +312,19 @@ def test_fuzz_mr_link2_loglik_alpha_h0(th, lam, cX, cY, nX, nY):
     # Compare both results using np.isclose()
     assert np.isclose(python_result, r_result_py, rtol=1e-5,
                       atol=1e-8), f"Mismatch for th={th}, lam={lam}, cX={cX}, cY={cY}, nX={nX}, nY={nY}"
+
+
+
+@pytest.mark.parametrize("th, lam, cX, cY, nX, nY", [
+    (np.array([1e-10, 1e-10, 1e-10]), np.array([1e-10, 1e-10, 1e-10]), np.array([1e-10, 1e-10, 1e-10]), np.array([1e-10, 1e-10, 1e-10]), 1e10, 1e10),
+    (np.array([1e10, 1e10, 1e10]), np.array([1e5, 1e5, 1e5]), np.array([1e2, 1e2, 1e2]), np.array([1e2, 1e2, 1e2]), 1e10, 1e5),
+    (np.array([0, 0, 0]), np.array([1, 2, 3]), np.array([0, 0, 0]), np.array([0, 0, 0]), 100, 100),
+    # Add other extreme cases here...
+])
+def test_edge_cases_mr_link2_loglik_reference_v2(th, lam, cX, cY, nX, nY):
+    """Test edge cases for equivalence between Python and R implementations."""
+    python_result = mr_link2_loglik_reference_v2(th, lam, cX, cY, nX, nY)
+    r_result = r['mr_link2_loglik_reference_v2'](th, lam, cX, cY, nX, nY)
+    r_result_py = float(r_result[0])
+
+    assert np.isclose(python_result, r_result_py, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
This pull request adds  R functions of MR-link-2  support if you have an associated region for exposure, the corresponding summary statistics for an outcome, and the LD matrix. loaded into R. 

The likelihood functions are tested to be equal, however, due to differences in the optimization algorithms between R and Python, the final optimized parameters are tested to be within about 5% from each other. this means that a P value will go from 0.1 to somewhere between[ 0.095, 0.105 ]

Perhaps superfluous, but the Python version is the reference.

For the moment these functions are there only if you know what you're doing. 
If you want more R support, feel free to send a message, and I'll make sure to help out!

